### PR TITLE
Release artifacts for release v1.4.0

### DIFF
--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: public.ecr.aws/aws-controllers-k8s/s3control-controller
-  newTag: 1.3.2
+  newTag: 1.4.0

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: s3control-chart
 description: A Helm chart for the ACK service controller for AWS S3 Control (S3 Control)
-version: 1.3.2
-appVersion: 1.3.2
+version: 1.4.0
+appVersion: 1.4.0
 home: https://github.com/aws-controllers-k8s/s3control-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{ .Chart.Name }} has been installed.
-This chart deploys "public.ecr.aws/aws-controllers-k8s/s3control-controller:1.3.2".
+This chart deploys "public.ecr.aws/aws-controllers-k8s/s3control-controller:1.4.0".
 
 Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/s3control-controller
-  tag: 1.3.2
+  tag: 1.4.0
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Release artifacts for s3control-controller **v1.4.0**.

## Type of bump
Minor (v1.3.2 → v1.4.0) — a new field was added to a CRD.

## Included since v1.3.2
- #42 fix: Support for S3 Access Point IAM Policy (adds the `Policy` field to the `AccessPoint` resource)

## Tooling versions
- code-generator: `v0.61.0` (HEAD `ab6940f`, matching `main`'s `build_hash`)
- ACK runtime: `v0.61.0`

## Diff
Version bump only (1.3.2 → 1.4.0):
- `config/controller/kustomization.yaml`
- `helm/Chart.yaml`
- `helm/templates/NOTES.txt`
- `helm/values.yaml`